### PR TITLE
Write log to project folder

### DIFF
--- a/AutomaticInterface/AutomaticInterface/AutomaticInterface.cs
+++ b/AutomaticInterface/AutomaticInterface/AutomaticInterface.cs
@@ -45,9 +45,12 @@ namespace AutomaticInterface
                 throw;
             }
 
-            static string GetLogPath()
+            string GetLogPath()
             {
-                string logDir = Environment.CurrentDirectory;
+                var mainSyntaxTree = context.Compilation.SyntaxTrees
+                    .First(x => x.HasCompilationUnitRoot);
+
+                string logDir = Path.GetDirectoryName(mainSyntaxTree.FilePath) ?? Environment.CurrentDirectory;
 
                 if (logDir.Contains("MSBuild"))
                 {


### PR DESCRIPTION
In my project it tries writing logs to C:\Program Files\dotnet\sdk\6.0.301\Roslyn\bincore\logs, I'm not sure why, maybe because I use Rider.
With this change it takes compilation root (project folder) for logs path