### PR TITLE
Fix IParameterSymbol usage

### DIFF
--- a/AutomaticInterface/AutomaticInterface/AutomaticInterface.cs
+++ b/AutomaticInterface/AutomaticInterface/AutomaticInterface.cs
@@ -160,10 +160,9 @@ public class AutomaticInterfaceGenerator : ISourceGenerator
 
     private static string GetMethodSignature(IParameterSymbol x)
     {
-        var optionalValue = string.Empty;
-        if (!x.HasExplicitDefaultValue) return $"{x.ToDisplayString()} {x.Name}{optionalValue}";
+        if (!x.HasExplicitDefaultValue) return $"{x.Type.ToDisplayString()} {x.Name}";
 
-        optionalValue = x.ExplicitDefaultValue switch
+        string optionalValue = x.ExplicitDefaultValue switch
         {
             string => $" = \"{x.ExplicitDefaultValue}\"",
             // struct
@@ -171,7 +170,7 @@ public class AutomaticInterfaceGenerator : ISourceGenerator
             null => " = null",
             _ => $" = {x.ExplicitDefaultValue}"
         };
-        return $"{x.ToDisplayString()} {x.Name}{optionalValue}";
+        return $"{x.Type.ToDisplayString()} {x.Name}{optionalValue}";
     }
 
     private static string GetDocumentationFor(IMethodSymbol method, ClassDeclarationSyntax classSyntax,

--- a/AutomaticInterface/AutomaticInterface/AutomaticInterface.csproj
+++ b/AutomaticInterface/AutomaticInterface/AutomaticInterface.csproj
@@ -25,7 +25,7 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <EnableNETAnalyzers>True</EnableNETAnalyzers>
         <AnalysisLevel>latest-Recommended</AnalysisLevel>
-        <Version>1.5.0</Version>
+        <Version>1.6.0</Version>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
     

--- a/AutomaticInterface/Tests/Tests.csproj
+++ b/AutomaticInterface/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <Configurations>Debug;Release;DebugGenerator</Configurations>
   </PropertyGroup>


### PR DESCRIPTION
The version 7.0.203 of .NET SDK introduces a breaking change to ToDisplayString method of IParameterSymbol returning `<type> <parameter name>` instead of `<type>`.

The solution is getting the ITypeSymbol from parameter symbol using the Type property.