### PR TITLE
Handle boolean default values correctly

### DIFF
--- a/AutomaticInterface/AutomaticInterface/Builder.cs
+++ b/AutomaticInterface/AutomaticInterface/Builder.cs
@@ -191,6 +191,7 @@ public static class Builder
         var optionalValue = x.ExplicitDefaultValue switch
         {
             string => $" = \"{x.ExplicitDefaultValue}\"",
+            bool value => $" = {(value ? "true" : "false")}",
             // struct
             null when x.Type.IsValueType => $" = default({x.Type})",
             null => " = null",

--- a/AutomaticInterface/Tests/GeneratorTests.cs
+++ b/AutomaticInterface/Tests/GeneratorTests.cs
@@ -56,7 +56,8 @@ public class GeneratorTests
                     public bool TryStartTransaction(
                         string file = "",
                         string member = "",
-                        int line = 0)
+                        int line = 0,
+                        bool notify = true)
                     {
             return true;
             }
@@ -82,7 +83,7 @@ public class GeneratorTests
                 public partial interface IDemoClass
                 {
                     /// <inheritdoc />
-                    bool TryStartTransaction(string file = "", string member = "", int line = 0);
+                    bool TryStartTransaction(string file = "", string member = "", int line = 0, bool notify = true);
                     
                 }
             }
@@ -1885,7 +1886,7 @@ public class GeneratorTests
                 public partial interface IDemoClass
                 {
                     /// <inheritdoc />
-                    Task<Stream?> GetFinalDocumentsByIDFails(string agreementID, string docType, bool amt = False, bool? attachSupportingDocuments = True, CancellationToken cancellationToken = null);
+                    Task<Stream?> GetFinalDocumentsByIDFails(string agreementID, string docType, bool amt = false, bool? attachSupportingDocuments = true, CancellationToken cancellationToken = null);
                     
                 }
             }
@@ -1957,7 +1958,7 @@ public class GeneratorTests
                 public partial interface IDemoClass
                 {
                     /// <inheritdoc />
-                    Task<Stream?> GetFinalDocumentsByIDFails(string agreementID, string docType, bool amt = False, bool? attachSupportingDocuments = True, CancellationToken cancellationToken = null);
+                    Task<Stream?> GetFinalDocumentsByIDFails(string agreementID, string docType, bool amt = false, bool? attachSupportingDocuments = true, CancellationToken cancellationToken = null);
                     
                 }
             }


### PR DESCRIPTION
This fixes a bug where boolean default values are generated with values `True` or `False`, which does not compile. This changes the generator to create these values as `true` or `false`.