### PR TITLE
Query the public members only once

### DIFF
--- a/AutomaticInterface/AutomaticInterface/AutomaticInterface.csproj
+++ b/AutomaticInterface/AutomaticInterface/AutomaticInterface.csproj
@@ -25,11 +25,11 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <EnableNETAnalyzers>True</EnableNETAnalyzers>
         <AnalysisLevel>latest-Recommended</AnalysisLevel>
-        <Version>5.0.1</Version>
+        <Version>5.0.2</Version>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <NoWarn>1701;1702;NU5128</NoWarn>
-        <PackageReleaseNotes>Use ForAttributeWithMetadataName to improve performance</PackageReleaseNotes>
+        <PackageReleaseNotes>Query members only once. Small optimization.</PackageReleaseNotes>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugGenerator|AnyCPU'">

--- a/AutomaticInterface/AutomaticInterface/Builder.cs
+++ b/AutomaticInterface/AutomaticInterface/Builder.cs
@@ -45,9 +45,17 @@ public static class Builder
 
         interfaceGenerator.AddClassDocumentation(GetDocumentationForClass(classSyntax));
         interfaceGenerator.AddGeneric(GetGeneric(classSyntax));
-        AddPropertiesToInterface(typeSymbol, interfaceGenerator);
-        AddMethodsToInterface(typeSymbol, interfaceGenerator);
-        AddEventsToInterface(typeSymbol, interfaceGenerator);
+
+        var members = typeSymbol
+            .GetAllMembers()
+            .Where(x => x.DeclaredAccessibility == Accessibility.Public)
+            .Where(x => !x.IsStatic)
+            .Where(x => !HasIgnoreAttribute(x))
+            .ToList();
+
+        AddPropertiesToInterface(members, interfaceGenerator);
+        AddMethodsToInterface(members, interfaceGenerator);
+        AddEventsToInterface(members, interfaceGenerator);
 
         var generatedCode = interfaceGenerator.Build();
 
@@ -74,19 +82,12 @@ public static class Builder
             : customNs!;
     }
 
-    private static void AddMethodsToInterface(
-        ITypeSymbol classSymbol,
-        InterfaceBuilder codeGenerator
-    )
+    private static void AddMethodsToInterface(List<ISymbol> members, InterfaceBuilder codeGenerator)
     {
-        classSymbol
-            .GetAllMembers()
+        members
             .Where(x => x.Kind == SymbolKind.Method)
             .OfType<IMethodSymbol>()
-            .Where(x => x.DeclaredAccessibility == Accessibility.Public)
             .Where(x => x.MethodKind == MethodKind.Ordinary)
-            .Where(x => !x.IsStatic)
-            .Where(x => !HasIgnoreAttribute(x))
             .Where(x => x.ContainingType.Name != nameof(Object))
             .Where(x => !HasIgnoreAttribute(x))
             .GroupBy(x => x.ToDisplayString(MethodSignatureDisplayFormat))
@@ -172,18 +173,11 @@ public static class Builder
         return false;
     }
 
-    private static void AddEventsToInterface(
-        ITypeSymbol classSymbol,
-        InterfaceBuilder codeGenerator
-    )
+    private static void AddEventsToInterface(List<ISymbol> members, InterfaceBuilder codeGenerator)
     {
-        classSymbol
-            .GetAllMembers()
+        members
             .Where(x => x.Kind == SymbolKind.Event)
             .OfType<IEventSymbol>()
-            .Where(x => x.DeclaredAccessibility == Accessibility.Public)
-            .Where(x => !x.IsStatic)
-            .Where(x => !HasIgnoreAttribute(x))
             .GroupBy(x => x.ToDisplayString(MethodSignatureDisplayFormat))
             .Select(g => g.First())
             .ToList()
@@ -253,18 +247,14 @@ public static class Builder
     }
 
     private static void AddPropertiesToInterface(
-        ITypeSymbol classSymbol,
+        List<ISymbol> members,
         InterfaceBuilder interfaceGenerator
     )
     {
-        classSymbol
-            .GetAllMembers()
+        members
             .Where(x => x.Kind == SymbolKind.Property)
             .OfType<IPropertySymbol>()
-            .Where(x => x.DeclaredAccessibility == Accessibility.Public)
-            .Where(x => !x.IsStatic)
             .Where(x => !x.IsIndexer)
-            .Where(x => !HasIgnoreAttribute(x))
             .GroupBy(x => x.Name)
             .Select(g => g.First())
             .ToList()

--- a/README.md
+++ b/README.md
@@ -185,10 +185,14 @@ Should be simply a build and run Tests
 
 ## Changelog
 
-### 5.0.0
+### 5.0.2
+
+- Query members only once. Small optimization. Thanks, @crwsolutions!
+
+### 5.0.1
 
 - Sync DemoClass and actual generated code with README. Thanks, @crwsolutions!
--  Removed manual attribute in TestNuget project. Thanks, @crwsolutions!
+- Removed manual attribute in TestNuget project. Thanks, @crwsolutions!
 
 ### 5.0.0
 


### PR DESCRIPTION
This will simplify the code and improve performance a littlebit. Small optimization.