### PR TITLE
Fixes #57: Improves inheritdoc so that developer documentation is properly referenced on the autogenerated interfaces

### DIFF
--- a/AutomaticInterface/AutomaticInterface/Builder.cs
+++ b/AutomaticInterface/AutomaticInterface/Builder.cs
@@ -9,7 +9,7 @@ namespace AutomaticInterface;
 
 public static class Builder
 {
-    private static string InheritDoc(string source) => $"/// <inheritdoc cref=\"{source}\" />"; // we use inherit doc because that should be able to fetch documentation from base classes.
+    private static string InheritDoc(string source) => $"/// <inheritdoc cref=\"{source.Replace('<', '{').Replace('>', '}')}\" />"; // we use inherit doc because that should be able to fetch documentation from base classes.
 
     private static readonly SymbolDisplayFormat MethodSignatureDisplayFormat =
         new(

--- a/AutomaticInterface/AutomaticInterface/Builder.cs
+++ b/AutomaticInterface/AutomaticInterface/Builder.cs
@@ -9,13 +9,14 @@ namespace AutomaticInterface;
 
 public static class Builder
 {
-    private static string InheritDoc(string source) => $"/// <inheritdoc cref=\"{source.Replace('<', '{').Replace('>', '}')}\" />"; // we use inherit doc because that should be able to fetch documentation from base classes.
+    private static string InheritDoc(ISymbol source) =>
+        $"/// <inheritdoc cref=\"{source.ToDisplayString().Replace('<', '{').Replace('>', '}')}\" />"; // we use inherit doc because that should be able to fetch documentation from base classes.
 
     private static readonly SymbolDisplayFormat MethodSignatureDisplayFormat =
         new(
             memberOptions: SymbolDisplayMemberOptions.IncludeParameters,
             parameterOptions: SymbolDisplayParameterOptions.IncludeType
-                              | SymbolDisplayParameterOptions.IncludeParamsRefOut
+                | SymbolDisplayParameterOptions.IncludeParamsRefOut
         );
 
     private static readonly SymbolDisplayFormat TypeDisplayFormat =
@@ -24,7 +25,7 @@ public static class Builder
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
             genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
             miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes
-                                  | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
+                | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
         );
 
     public static string BuildInterfaceFor(ITypeSymbol typeSymbol)
@@ -93,7 +94,7 @@ public static class Builder
             .GroupBy(x => x.ToDisplayString(MethodSignatureDisplayFormat))
             .Select(g => g.First())
             .ToList()
-            .ForEach(method => { AddMethod(codeGenerator, method); });
+            .ForEach(method => AddMethod(codeGenerator, method));
     }
 
     private static void AddMethod(InterfaceBuilder codeGenerator, IMethodSymbol method)
@@ -115,7 +116,7 @@ public static class Builder
         codeGenerator.AddMethodToInterface(
             name,
             returnType.ToDisplayString(TypeDisplayFormat),
-            InheritDoc(method.ToDisplayString()),
+            InheritDoc(method),
             paramResult,
             typedArgs
         );
@@ -195,7 +196,7 @@ public static class Builder
                 codeGenerator.AddEventToInterface(
                     name,
                     type.ToDisplayString(TypeDisplayFormat),
-                    InheritDoc(evt.ToDisplayString())
+                    InheritDoc(evt)
                 );
             });
     }
@@ -283,7 +284,7 @@ public static class Builder
                     hasGet,
                     hasSet,
                     isRef,
-                    InheritDoc(prop.ToDisplayString())
+                    InheritDoc(prop)
                 );
             });
     }

--- a/AutomaticInterface/AutomaticInterface/Builder.cs
+++ b/AutomaticInterface/AutomaticInterface/Builder.cs
@@ -9,13 +9,13 @@ namespace AutomaticInterface;
 
 public static class Builder
 {
-    private const string InheritDoc = "/// <inheritdoc />"; // we use inherit doc because that should be able to fetch documentation from base classes.
+    private static string InheritDoc(string source) => $"/// <inheritdoc cref=\"{source}\" />"; // we use inherit doc because that should be able to fetch documentation from base classes.
 
     private static readonly SymbolDisplayFormat MethodSignatureDisplayFormat =
         new(
             memberOptions: SymbolDisplayMemberOptions.IncludeParameters,
             parameterOptions: SymbolDisplayParameterOptions.IncludeType
-                | SymbolDisplayParameterOptions.IncludeParamsRefOut
+                              | SymbolDisplayParameterOptions.IncludeParamsRefOut
         );
 
     private static readonly SymbolDisplayFormat TypeDisplayFormat =
@@ -24,7 +24,7 @@ public static class Builder
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
             genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
             miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes
-                | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
+                                  | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
         );
 
     public static string BuildInterfaceFor(ITypeSymbol typeSymbol)
@@ -67,6 +67,7 @@ public static class Builder
         {
             return typeSymbol.ContainingNamespace.ToDisplayString();
         }
+
         var customNs = generationAttribute.ConstructorArguments.FirstOrDefault().Value?.ToString();
 
         return string.IsNullOrWhiteSpace(customNs)
@@ -92,10 +93,7 @@ public static class Builder
             .GroupBy(x => x.ToDisplayString(MethodSignatureDisplayFormat))
             .Select(g => g.First())
             .ToList()
-            .ForEach(method =>
-            {
-                AddMethod(codeGenerator, method);
-            });
+            .ForEach(method => { AddMethod(codeGenerator, method); });
     }
 
     private static void AddMethod(InterfaceBuilder codeGenerator, IMethodSymbol method)
@@ -117,7 +115,7 @@ public static class Builder
         codeGenerator.AddMethodToInterface(
             name,
             returnType.ToDisplayString(TypeDisplayFormat),
-            InheritDoc,
+            InheritDoc(method.ToDisplayString()),
             paramResult,
             typedArgs
         );
@@ -197,7 +195,7 @@ public static class Builder
                 codeGenerator.AddEventToInterface(
                     name,
                     type.ToDisplayString(TypeDisplayFormat),
-                    InheritDoc
+                    InheritDoc(evt.ToDisplayString())
                 );
             });
     }
@@ -285,7 +283,7 @@ public static class Builder
                     hasGet,
                     hasSet,
                     isRef,
-                    InheritDoc
+                    InheritDoc(prop.ToDisplayString())
                 );
             });
     }

--- a/AutomaticInterface/AutomaticInterface/Builder.cs
+++ b/AutomaticInterface/AutomaticInterface/Builder.cs
@@ -222,8 +222,8 @@ public static class Builder
             string => $" = \"{x.ExplicitDefaultValue}\"",
             bool value => $" = {(value ? "true" : "false")}",
             // struct
-            null when x.Type.IsValueType =>
-                $" = default({x.Type.ToDisplayString(TypeDisplayFormat)})",
+            null when x.Type.IsValueType
+                => $" = default({x.Type.ToDisplayString(TypeDisplayFormat)})",
             null => " = null",
             _ => $" = {x.ExplicitDefaultValue}",
         };
@@ -294,11 +294,12 @@ public static class Builder
         return setMethodSymbol switch
         {
             null => PropertySetKind.NoSet,
-            { IsInitOnly: true, DeclaredAccessibility: Accessibility.Public } =>
-                PropertySetKind.Init,
-            _ => setMethodSymbol is { DeclaredAccessibility: Accessibility.Public }
-                ? PropertySetKind.Always
-                : PropertySetKind.NoSet,
+            { IsInitOnly: true, DeclaredAccessibility: Accessibility.Public }
+                => PropertySetKind.Init,
+            _
+                => setMethodSymbol is { DeclaredAccessibility: Accessibility.Public }
+                    ? PropertySetKind.Always
+                    : PropertySetKind.NoSet,
         };
     }
 

--- a/AutomaticInterface/AutomaticInterface/Builder.cs
+++ b/AutomaticInterface/AutomaticInterface/Builder.cs
@@ -222,10 +222,10 @@ public static class Builder
             string => $" = \"{x.ExplicitDefaultValue}\"",
             bool value => $" = {(value ? "true" : "false")}",
             // struct
-            null when x.Type.IsValueType
-                => $" = default({x.Type.ToDisplayString(TypeDisplayFormat)})",
+            null when x.Type.IsValueType =>
+                $" = default({x.Type.ToDisplayString(TypeDisplayFormat)})",
             null => " = null",
-            _ => $" = {x.ExplicitDefaultValue}"
+            _ => $" = {x.ExplicitDefaultValue}",
         };
     }
 
@@ -294,12 +294,11 @@ public static class Builder
         return setMethodSymbol switch
         {
             null => PropertySetKind.NoSet,
-            { IsInitOnly: true, DeclaredAccessibility: Accessibility.Public }
-                => PropertySetKind.Init,
-            _
-                => setMethodSymbol is { DeclaredAccessibility: Accessibility.Public }
-                    ? PropertySetKind.Always
-                    : PropertySetKind.NoSet
+            { IsInitOnly: true, DeclaredAccessibility: Accessibility.Public } =>
+                PropertySetKind.Init,
+            _ => setMethodSymbol is { DeclaredAccessibility: Accessibility.Public }
+                ? PropertySetKind.Always
+                : PropertySetKind.NoSet,
         };
     }
 
@@ -327,7 +326,7 @@ public static class Builder
             SyntaxKind.DocumentationCommentExteriorTrivia,
             SyntaxKind.EndOfDocumentationCommentToken,
             SyntaxKind.MultiLineDocumentationCommentTrivia,
-            SyntaxKind.SingleLineDocumentationCommentTrivia
+            SyntaxKind.SingleLineDocumentationCommentTrivia,
         ];
 
         var trivia = classSyntax

--- a/AutomaticInterface/AutomaticInterface/InterfaceBuilder.cs
+++ b/AutomaticInterface/AutomaticInterface/InterfaceBuilder.cs
@@ -153,7 +153,7 @@ namespace AutomaticInterface
                 PropertySetKind.NoSet => string.Empty,
                 PropertySetKind.Always => "set; ",
                 PropertySetKind.Init => "init; ",
-                _ => throw new ArgumentOutOfRangeException(nameof(propSetKind), propSetKind, null)
+                _ => throw new ArgumentOutOfRangeException(nameof(propSetKind), propSetKind, null),
             };
         }
 

--- a/AutomaticInterface/AutomaticInterfaceExample/DemoClass.cs
+++ b/AutomaticInterface/AutomaticInterfaceExample/DemoClass.cs
@@ -38,6 +38,17 @@ namespace AutomaticInterfaceExample
             return x + y;
         }
 
+        /// <summary>
+        /// CMethod allows operations with multiple generic type parameters and string inputs.
+        /// </summary>
+        /// <typeparam name="T">The first generic type parameter which must be a class.</typeparam>
+        /// <typeparam name="T1">The second generic type parameter which must be a structure.</typeparam>
+        /// <typeparam name="T2">The third generic type parameter.</typeparam>
+        /// <typeparam name="T3">The fourth generic type parameter which must be derived from DemoClass.</typeparam>
+        /// <typeparam name="T4">The fifth generic type parameter which must implement IDemoClass.</typeparam>
+        /// <param name="x">The optional first string input parameter.</param>
+        /// <param name="y">The second string input parameter.</param>
+        /// <return>Returns a string result.</return>
         public string CMethod<T, T1, T2, T3, T4>(string? x, string y) // included
             where T : class
             where T1 : struct

--- a/AutomaticInterface/AutomaticInterfaceExample/DemoClassWithCustomNamespace.cs
+++ b/AutomaticInterface/AutomaticInterfaceExample/DemoClassWithCustomNamespace.cs
@@ -15,6 +15,11 @@ namespace AutomaticInterfaceExample
     )]
     public class DemoClass2 : IDemoClass2
     {
-        public void Test() { }
+        /// <summary>
+        /// This is a test method
+        /// </summary>
+        public void Test()
+        {
+        }
     }
 }

--- a/AutomaticInterface/AutomaticInterfaceExample/DemoClassWithCustomNamespace.cs
+++ b/AutomaticInterface/AutomaticInterfaceExample/DemoClassWithCustomNamespace.cs
@@ -18,8 +18,6 @@ namespace AutomaticInterfaceExample
         /// <summary>
         /// This is a test method
         /// </summary>
-        public void Test()
-        {
-        }
+        public void Test() { }
     }
 }

--- a/AutomaticInterface/AutomaticInterfaceExample/Program.cs
+++ b/AutomaticInterface/AutomaticInterfaceExample/Program.cs
@@ -15,6 +15,7 @@ namespace AutomaticInterfaceExample
 
             IDemoClass demoInterface = demo;
             Console.WriteLine(demoInterface.AMethod("A", "B"));
+            Console.WriteLine(demoInterface.CMethod<string, int, uint, DemoClass, DemoClass>("A", "B"));
             Console.WriteLine("Hello World!");
         }
     }

--- a/AutomaticInterface/AutomaticInterfaceExample/Program.cs
+++ b/AutomaticInterface/AutomaticInterfaceExample/Program.cs
@@ -15,7 +15,9 @@ namespace AutomaticInterfaceExample
 
             IDemoClass demoInterface = demo;
             Console.WriteLine(demoInterface.AMethod("A", "B"));
-            Console.WriteLine(demoInterface.CMethod<string, int, uint, DemoClass, DemoClass>("A", "B"));
+            Console.WriteLine(
+                demoInterface.CMethod<string, int, uint, DemoClass, DemoClass>("A", "B")
+            );
             Console.WriteLine("Hello World!");
         }
     }

--- a/AutomaticInterface/Tests/GeneratorTests.Properties.cs
+++ b/AutomaticInterface/Tests/GeneratorTests.Properties.cs
@@ -39,7 +39,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello" />
                     string Hello { get; }
                     
                 }
@@ -85,7 +85,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello" />
                     string Hello { get; }
                     
                 }
@@ -139,7 +139,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.NullableProperty" />
                     string? NullableProperty { get; set; }
                     
                 }
@@ -195,7 +195,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.NullableProperty" />
                     global::System.Threading.Tasks.Task<string?> NullableProperty { get; set; }
                     
                 }
@@ -243,7 +243,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface ISecondClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.SecondClass.AProperty" />
                     int AProperty { get; set; }
                     
                 }
@@ -288,7 +288,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.SomeProperty" />
                     string SomeProperty { get; set; }
                     
                 }
@@ -334,7 +334,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.SomeProperty" />
                     string SomeProperty { get; set; }
                     
                 }
@@ -377,7 +377,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello" />
                     string Hello { get; set; }
                     
                 }
@@ -421,7 +421,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello" />
                     string Hello { set; }
                     
                 }
@@ -465,7 +465,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello" />
                     string Hello { get; }
                     
                 }
@@ -508,7 +508,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello" />
                     string Hello { get; init; }
                     
                 }

--- a/AutomaticInterface/Tests/GeneratorTests.TypeResolution.cs
+++ b/AutomaticInterface/Tests/GeneratorTests.TypeResolution.cs
@@ -35,7 +35,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello" />
                     string Hello { get; set; }
                     
                 }
@@ -77,7 +77,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello" />
                     string Hello { get; set; }
                     
                 }
@@ -120,7 +120,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello" />
                     global::System.Threading.Tasks.Task Hello { get; set; }
                     
                 }
@@ -169,10 +169,10 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IModelManager
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.ModelManager.GetModel1()" />
                     global::AutomaticInterfaceExample.Models1.Model GetModel1();
                     
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.ModelManager.GetModel2()" />
                     global::AutomaticInterfaceExample.Models2.Model GetModel2();
                     
                 }
@@ -222,7 +222,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IModelManager
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="RootNamespace.ModelManager.ModelManager.GetModel()" />
                     global::RootNamespace.Models.Model GetModel();
                     
                 }
@@ -268,7 +268,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.GetTask()" />
                     global::System.Threading.Tasks.Task GetTask();
                     
                 }
@@ -314,7 +314,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.GetClass()" />
                     global::GlobalNamespace.AClass GetClass();
                     
                 }

--- a/AutomaticInterface/Tests/GeneratorTests.cs
+++ b/AutomaticInterface/Tests/GeneratorTests.cs
@@ -87,7 +87,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.TryStartTransaction(string, string, int, bool)" />
                     bool TryStartTransaction(string file = "", string member = "", int line = 0, bool notify = true);
                     
                 }
@@ -136,7 +136,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.TryStartTransaction(AutomaticInterfaceExample.MyStruct)" />
                     bool TryStartTransaction(global::AutomaticInterfaceExample.MyStruct data = default(global::AutomaticInterfaceExample.MyStruct));
                     
                 }
@@ -180,7 +180,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.TryStartTransaction(string)" />
                     bool TryStartTransaction(string data = null);
                     
                 }
@@ -263,7 +263,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello()" />
                     string Hello();
                     
                 }
@@ -308,7 +308,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello()" />
                     global::System.Threading.Tasks.Task<string> Hello();
                     
                 }
@@ -353,7 +353,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello(string)" />
                     string Hello(string x);
                     
                 }
@@ -398,7 +398,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello(System.Threading.Tasks.Task<string>)" />
                     string Hello(global::System.Threading.Tasks.Task<string> x);
                     
                 }
@@ -442,7 +442,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello(string, int, double)" />
                     string Hello(string x, int y, double z);
                     
                 }
@@ -577,7 +577,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello(string)" />
                     string Hello(string x);
                     
                 }
@@ -625,7 +625,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello(string)" />
                     string Hello(string x);
                     
                 }
@@ -673,7 +673,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello" />
                     string Hello { get; }
                     
                 }
@@ -726,7 +726,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello" />
                     string Hello { get; }
                     
                 }
@@ -875,7 +875,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.ShapeChanged" />
                     event global::System.EventHandler ShapeChanged;
                     
                 }
@@ -1021,16 +1021,16 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello" />
                     string Hello { get; set; }
                     
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.OnlyGet" />
                     string OnlyGet { get; }
                     
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(string, string)" />
                     string AMethod(string x, string y);
                     
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.ShapeChanged" />
                     event global::System.EventHandler ShapeChanged;
                     
                 }
@@ -1080,7 +1080,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.CMethod<T, T1, T2, T3, T4>(string, string)" />
                     string CMethod<T, T1, T2, T3, T4>(string x, string y) where T : class where T1 : struct where T3 : global::AutomaticInterfaceExample.DemoClass where T4 : IDemoClass;
                     
                 }
@@ -1131,10 +1131,10 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(string, string)" />
                     string AMethod(string x, string y);
                     
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(string, string, string)" />
                     string AMethod(string x, string y, string crash);
                     
                 }
@@ -1177,7 +1177,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(AutomaticInterfaceExample.DemoClass?, string)" />
                     string AMethod(global::AutomaticInterfaceExample.DemoClass? x, string y);
                     
                 }
@@ -1221,7 +1221,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(AutomaticInterfaceExample.DemoClass, string)" />
                     string? AMethod(global::AutomaticInterfaceExample.DemoClass x, string y);
                     
                 }
@@ -1276,7 +1276,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.ShapeChangedNullable" />
                     event global::System.EventHandler? ShapeChangedNullable;
                     
                 }
@@ -1331,7 +1331,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.ShapeChangedNullable" />
                     event global::System.EventHandler<string?> ShapeChangedNullable;
                     
                 }
@@ -1396,7 +1396,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.GetFinalDocumentsByIDFails(string, string, bool, bool?, System.Threading.CancellationToken)" />
                     global::System.Threading.Tasks.Task<global::System.IO.Stream?> GetFinalDocumentsByIDFails(string agreementID, string docType, bool amt = false, bool? attachSupportingDocuments = true, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken));
                     
                 }
@@ -1461,7 +1461,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.GetFinalDocumentsByIDFails(string, string, bool, bool?, System.Threading.CancellationToken)" />
                     global::System.Threading.Tasks.Task<global::System.IO.Stream?> GetFinalDocumentsByIDFails(string agreementID, string docType, bool amt = false, bool? attachSupportingDocuments = true, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken));
                     
                 }
@@ -1507,7 +1507,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethodAsync(AutomaticInterfaceExample.DemoClass, string)" />
                     global::System.Threading.Tasks.Task<string?> AMethodAsync(global::AutomaticInterfaceExample.DemoClass x, string y);
                     
                 }
@@ -1553,7 +1553,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(System.Threading.Tasks.Task<AutomaticInterfaceExample.DemoClass?>, string)" />
                     string AMethod(global::System.Threading.Tasks.Task<global::AutomaticInterfaceExample.DemoClass?> x, string y);
                     
                 }
@@ -1596,7 +1596,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AProperty" />
                     ref string AProperty { get; }
                     
                 }
@@ -1639,7 +1639,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(int)" />
                     void AMethod(int @event);
                     
                 }
@@ -1685,7 +1685,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod()" />
                     bool AMethod();
                     
                 }
@@ -1731,7 +1731,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod()" />
                     bool AMethod();
                     
                 }
@@ -1774,10 +1774,10 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(int)" />
                     void AMethod(int val);
                     
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(ref int)" />
                     void AMethod(ref int val);
                     
                 }
@@ -1824,7 +1824,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AnEvent" />
                     event global::System.EventHandler AnEvent;
                     
                 }
@@ -1871,7 +1871,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AnEvent" />
                     event global::System.EventHandler AnEvent;
                     
                 }

--- a/AutomaticInterface/Tests/GeneratorTests.cs
+++ b/AutomaticInterface/Tests/GeneratorTests.cs
@@ -398,7 +398,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello(System.Threading.Tasks.Task<string>)" />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello(System.Threading.Tasks.Task{string})" />
                     string Hello(global::System.Threading.Tasks.Task<string> x);
                     
                 }
@@ -1080,7 +1080,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.CMethod<T, T1, T2, T3, T4>(string, string)" />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.CMethod{T, T1, T2, T3, T4}(string, string)" />
                     string CMethod<T, T1, T2, T3, T4>(string x, string y) where T : class where T1 : struct where T3 : global::AutomaticInterfaceExample.DemoClass where T4 : IDemoClass;
                     
                 }
@@ -1553,7 +1553,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(System.Threading.Tasks.Task<AutomaticInterfaceExample.DemoClass?>, string)" />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(System.Threading.Tasks.Task{AutomaticInterfaceExample.DemoClass?}, string)" />
                     string AMethod(global::System.Threading.Tasks.Task<global::AutomaticInterfaceExample.DemoClass?> x, string y);
                     
                 }

--- a/AutomaticInterface/Tests/GeneratorsTests.MethodParameters.cs
+++ b/AutomaticInterface/Tests/GeneratorsTests.MethodParameters.cs
@@ -39,7 +39,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(out int)" />
                     void AMethod(out int someOutParameter);
                     
                 }
@@ -82,7 +82,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(in int)" />
                     void AMethod(in int someOutParameter);
                     
                 }
@@ -125,7 +125,7 @@ public partial class GeneratorTests
                 [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
                 public partial interface IDemoClass
                 {
-                    /// <inheritdoc />
+                    /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(ref int)" />
                     void AMethod(ref int someOutParameter);
                     
                 }

--- a/README.md
+++ b/README.md
@@ -105,28 +105,28 @@ namespace AutomaticInterfaceExample
     [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
     public partial interface IDemoClass
     {
-        /// <inheritdoc />
+        /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.Hello" />
         string Hello { get; set; }
         
-        /// <inheritdoc />
+        /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.OnlyGet" />
         string OnlyGet { get; }
         
-        /// <inheritdoc />
+        /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(string, string)" />
         string AMethod(string x, string y);
         
-        /// <inheritdoc />
-        string CMethod<T, T1, T2, T3, T4>(string? x, string y) where T : class where T1 : struct where T3 : DemoClass where T4 : IDemoClass;
+        /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.CMethod<T, T1, T2, T3, T4>(string?, string)" />
+        string CMethod<T, T1, T2, T3, T4>(string? x, string y) where T : class where T1 : struct where T3 : global::AutomaticInterfaceExample.DemoClass where T4 : IDemoClass;
         
-        /// <inheritdoc />
+        /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.ASync(string, string)" />
         global::System.Threading.Tasks.Task<string> ASync(string x, string y);
         
-        /// <inheritdoc />
+        /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.ShapeChanged" />
         event global::System.EventHandler ShapeChanged;
         
-        /// <inheritdoc />
+        /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.ShapeChangedNullable" />
         event global::System.EventHandler? ShapeChangedNullable;
         
-        /// <inheritdoc />
+        /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.ShapeChangedNullable2" />
         event global::System.EventHandler<string?> ShapeChangedNullable2;
         
     }

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ namespace AutomaticInterfaceExample
         /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(string, string)" />
         string AMethod(string x, string y);
         
-        /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.CMethod<T, T1, T2, T3, T4>(string?, string)" />
+        /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.CMethod{T, T1, T2, T3, T4}(string?, string)" />
         string CMethod<T, T1, T2, T3, T4>(string? x, string y) where T : class where T1 : struct where T3 : global::AutomaticInterfaceExample.DemoClass where T4 : IDemoClass;
         
         /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.ASync(string, string)" />


### PR DESCRIPTION
based on the comments in #57, by using a `cref` back to the original implementation, we are able to get intellisense working off of autogenerated interfaces.

Resolves #57