### PR TITLE
feat: Exclude generated attributes from code coverage

### DIFF
--- a/AutomaticInterface/AutomaticInterface/RegisterAttributesExtensions.cs
+++ b/AutomaticInterface/AutomaticInterface/RegisterAttributesExtensions.cs
@@ -27,6 +27,8 @@ internal static class RegisterAttributesExtensions
                         /// <param name="namespaceName">Namespace name for the generated interface. Defaults to the same namespace as the class.</param>
                         /// <param name="interfaceName">Interface name for the generated interface. Defaults to an interface version of the class name.</param>
                         [AttributeUsage(AttributeTargets.Class)]
+                        [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
+                        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                         internal sealed class {{{AutomaticInterfaceGenerator.DefaultAttributeName}}}Attribute : Attribute
                         {
                             internal {{{AutomaticInterfaceGenerator.DefaultAttributeName}}}Attribute(string {{{AutomaticInterfaceGenerator.NamespaceParameterName}}} = "", string {{{AutomaticInterfaceGenerator.InterfaceParameterName}}} = "", bool asInternal = false) { }
@@ -59,6 +61,8 @@ internal static class RegisterAttributesExtensions
                         /// Ignore this member in a generated Interface from this class
                         /// </summary>
                         [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Event)]
+                        [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
+                        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                         internal sealed class {{{AutomaticInterfaceGenerator.IgnoreAutomaticInterfaceAttributeName}}}Attribute : Attribute
                         {
                             internal {{{AutomaticInterfaceGenerator.IgnoreAutomaticInterfaceAttributeName}}}Attribute() { }


### PR DESCRIPTION
### What’s changed

Two internal attribute types in **RegisterAttributesExtensions.cs** are now marked as generated code and excluded from code-coverage analysis.

* **GeneratedCode** attribute signals to tools that these types are auto-generated.
* **ExcludeFromCodeCoverage** ensures coverage reports (e.g. Coverlet, Visual Studio) skip these classes.

### Why

Coverage tools can skew metrics by including boilerplate attribute definitions that aren’t hand-written or relevant to business logic. By marking them as generated and excluding them, we:

* Keep overall coverage percentages meaningful
* Avoid noise when tracking real coverage gaps
* Follow best practices for generated code hygiene

### How to verify

1. Run your coverage suite (e.g. `dotnet test /p:CollectCoverage=true`).
2. Observe that neither of the two attribute classes appears in the coverage report.
3. Confirm no other tests or behavior have regressed.