### PR TITLE
Fix cref for methods with params

### DIFF
--- a/AutomaticInterface/AutomaticInterface/Builder.cs
+++ b/AutomaticInterface/AutomaticInterface/Builder.cs
@@ -10,7 +10,7 @@ namespace AutomaticInterface;
 public static class Builder
 {
     private static string InheritDoc(ISymbol source) =>
-        $"/// <inheritdoc cref=\"{source.ToDisplayString().Replace('<', '{').Replace('>', '}')}\" />"; // we use inherit doc because that should be able to fetch documentation from base classes.
+        $"/// <inheritdoc cref=\"{source.ToDisplayString().Replace('<', '{').Replace('>', '}').Replace("params ", "")}\" />"; // we use inherit doc because that should be able to fetch documentation from base classes.
 
     private static readonly SymbolDisplayFormat FullyQualifiedDisplayFormat =
         new(

--- a/AutomaticInterface/Tests/Methods/Methods.WorksWithParamsParameters.verified.txt
+++ b/AutomaticInterface/Tests/Methods/Methods.WorksWithParamsParameters.verified.txt
@@ -11,7 +11,7 @@ namespace AutomaticInterfaceExample
     [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
     public partial interface IDemoClass
     {
-        /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(params int[])" />
+        /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.AMethod(int[])" />
         void AMethod(params int[] numbers);
         
     }


### PR DESCRIPTION
The cref in inheritdoc is currently wrong, when a method has a params parameter. The params part should be removed.