### PR TITLE
Fix nullable annotation for types with generics

### DIFF
--- a/AutomaticInterface/AutomaticInterface/AddNullableAnnotationSyntaxRewriter.cs
+++ b/AutomaticInterface/AutomaticInterface/AddNullableAnnotationSyntaxRewriter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace AutomaticInterface
+{
+    internal sealed class AddNullableAnnotationSyntaxRewriter : CSharpSyntaxRewriter
+    {
+        public override SyntaxNode? VisitParameter(ParameterSyntax node)
+        {
+            var newNode = node;
+            if (node.Type != null)
+            {
+                newNode = node.WithType(
+                    SyntaxFactory.ParseTypeName(
+                        node.Type.GetLeadingTrivia()
+                            + node.Type.ToString()
+                            + "?"
+                            + node.Type.GetTrailingTrivia()
+                    )
+                );
+            }
+            return base.VisitParameter(newNode);
+        }
+    }
+}

--- a/AutomaticInterface/AutomaticInterface/Builder.cs
+++ b/AutomaticInterface/AutomaticInterface/Builder.cs
@@ -192,26 +192,6 @@ public static class Builder
         bool nullableContextEnabled
     )
     {
-        var paramParts = param.ToDisplayParts(FullyQualifiedDisplayFormat);
-        var typeSb = new StringBuilder();
-        var restSb = new StringBuilder();
-        var isInsideType = true;
-        // The part before the first space is the parameter type
-        foreach (var part in paramParts)
-        {
-            if (isInsideType && part.Kind == SymbolDisplayPartKind.Space)
-            {
-                isInsideType = false;
-            }
-            if (isInsideType)
-            {
-                typeSb.Append(part.ToString());
-            }
-            else
-            {
-                restSb.Append(part.ToString());
-            }
-        }
         // If this parameter has default value null and we're enabling the nullable context, we need to force the nullable annotation if there isn't one already
         if (
             param.HasExplicitDefaultValue
@@ -221,9 +201,12 @@ public static class Builder
             && nullableContextEnabled
         )
         {
-            typeSb.Append('?');
+            var addNullable = new AddNullableAnnotationSyntaxRewriter();
+            return addNullable
+                .Visit(param.DeclaringSyntaxReferences.First().GetSyntax())
+                .ToFullString();
         }
-        return typeSb.Append(restSb).ToString();
+        return param.ToDisplayString(FullyQualifiedDisplayFormat);
     }
 
     private static void AddEventsToInterface(List<ISymbol> members, InterfaceBuilder codeGenerator)

--- a/AutomaticInterface/Tests/Methods/Methods.WorksWithMixedOptionalNullParameters.verified.txt
+++ b/AutomaticInterface/Tests/Methods/Methods.WorksWithMixedOptionalNullParameters.verified.txt
@@ -12,8 +12,8 @@ namespace AutomaticInterfaceExample
     [global::System.CodeDom.Compiler.GeneratedCode("AutomaticInterface", "")]
     public partial interface IDemoClass
     {
-        /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.TryStartTransaction(int?, int, string)" />
-        bool TryStartTransaction(int? param, int param2 = 0, string? data = null);
+        /// <inheritdoc cref="AutomaticInterfaceExample.DemoClass.TryStartTransaction(int?, int, string, Func{int, int})" />
+        bool TryStartTransaction(int? param, int param2 = 0, string? data = null, Func<int, int>? func = null);
         
     }
 }

--- a/AutomaticInterface/Tests/Methods/Methods.cs
+++ b/AutomaticInterface/Tests/Methods/Methods.cs
@@ -88,10 +88,10 @@ public class Methods
             [GenerateAutomaticInterface]
             public class DemoClass
             {
-                    public bool TryStartTransaction(int? param, int param2 = 0, string data = null)
-                    {
-            return true;
-            }
+                public bool TryStartTransaction(int? param, int param2 = 0, string data = null, Func<int, int> func = null)
+                {
+                    return true;
+                }
             }
 
 


### PR DESCRIPTION
This is a correction for my PR #85 a few months ago.
The current code generates invalid syntax for a null parameter with generic arguments because it searches for the first whitespace.
`Func<int,? int> func = null`

I switched to a CSharpSyntaxRewriter, which hopefully properly handles all other cases that might exist.